### PR TITLE
fix: 修复循环导入、资源泄漏及遗留审计问题

### DIFF
--- a/packages/app.py
+++ b/packages/app.py
@@ -1,8 +1,12 @@
 from __future__ import annotations
 
+from collections.abc import Awaitable, Callable
 from pathlib import Path
 from types import ModuleType
-from typing import cast
+from typing import TYPE_CHECKING, cast
+
+if TYPE_CHECKING:
+    from .bootstrap.config import BootstrapConfig
 
 from .conversations import (
     ConfigurationContext,
@@ -46,7 +50,6 @@ from .schema import ObjectSchema, SchemaRegistry
 from .tools import ToolRegistry
 from .tools.mcp.manager import MCPManager
 from .skills.manager import SkillManager
-from .bootstrap.config import BootstrapConfig, save_app_config, load_app_config
 
 
 class NekoBotFramework:
@@ -89,6 +92,7 @@ class NekoBotFramework:
 
     async def update_framework_config(self, new_config: BootstrapConfig) -> None:
         """原子更新全局配置并触发观察者。"""
+        from .bootstrap.config import save_app_config  # lazy: avoids app ↔ bootstrap circular import
         save_app_config(new_config)
         for observer in self._config_observers:
             await observer(new_config)

--- a/packages/bootstrap/config.py
+++ b/packages/bootstrap/config.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import cast
+from typing import Any, cast
 
 from ..providers.types import ValueMap
 from .defaults import DEFAULT_CONFIG, INITIAL_CONFIG_TEMPLATE

--- a/packages/providers/sources/anthropic.py
+++ b/packages/providers/sources/anthropic.py
@@ -93,7 +93,9 @@ class AnthropicChatProvider(ChatProvider):
 
     @override
     async def teardown(self) -> None:
-        self._client = None
+        if self._client is not None:
+            await self._client.aclose()
+            self._client = None
 
     async def _build_messages(self, request: ProviderRequest) -> list[MessageParam]:
         messages: list[MessageParam] = []

--- a/packages/routers/app.py
+++ b/packages/routers/app.py
@@ -9,11 +9,22 @@ from ..app import NekoBotFramework
 from . import routes
 
 
+_DEFAULT_ORIGINS = frozenset({
+    "http://localhost:6285",
+    "http://127.0.0.1:6285",
+})
+
+
 def _allowed_origins() -> frozenset[str]:
-    """Read comma-separated allowed origins from NEKOBOT_CORS_ORIGINS env var."""
+    """Read comma-separated allowed origins from NEKOBOT_CORS_ORIGINS env var.
+    Defaults to localhost:6285 when not set.
+    Set NEKOBOT_CORS_ORIGINS=* to disable CORS restrictions (development only).
+    """
     raw = os.environ.get("NEKOBOT_CORS_ORIGINS", "").strip()
     if not raw:
-        return frozenset()
+        return _DEFAULT_ORIGINS
+    if raw == "*":
+        return frozenset({"*"})
     return frozenset(o.strip() for o in raw.split(",") if o.strip())
 
 
@@ -24,26 +35,32 @@ def create_app(framework: NekoBotFramework) -> Quart:
     """创建并配置 Quart 实例，接入核心框架依赖。"""
     app = Quart(__name__)
 
+    def _cors_origin(origin: str) -> str | None:
+        if "*" in _CORS_ORIGINS:
+            return "*"
+        return origin if origin in _CORS_ORIGINS else None
+
     @app.after_request
     async def add_cors_headers(response: Response) -> Response:
-        if not _CORS_ORIGINS:
-            return response
         origin = request.headers.get("Origin", "")
-        if origin in _CORS_ORIGINS:
-            response.headers["Access-Control-Allow-Origin"] = origin
+        allowed = _cors_origin(origin)
+        if allowed:
+            response.headers["Access-Control-Allow-Origin"] = allowed
             response.headers["Access-Control-Allow-Methods"] = "GET, POST, OPTIONS, PUT, DELETE"
             response.headers["Access-Control-Allow-Headers"] = "Content-Type, Authorization"
-            response.headers["Vary"] = "Origin"
+            if allowed != "*":
+                response.headers["Vary"] = "Origin"
         return response
 
     @app.route("/", defaults={"path": ""}, methods=["OPTIONS"])
     @app.route("/<path:path>", methods=["OPTIONS"])
     async def cors_preflight(path: str) -> Response:
         origin = request.headers.get("Origin", "")
-        if origin not in _CORS_ORIGINS:
+        allowed = _cors_origin(origin)
+        if not allowed:
             return Response("", status=403)
         return Response("", status=204, headers={
-            "Access-Control-Allow-Origin": origin,
+            "Access-Control-Allow-Origin": allowed,
             "Access-Control-Allow-Methods": "GET, POST, OPTIONS, PUT, DELETE",
             "Access-Control-Allow-Headers": "Content-Type, Authorization",
             "Vary": "Origin",

--- a/packages/routers/auth_store.py
+++ b/packages/routers/auth_store.py
@@ -11,9 +11,13 @@ _DEFAULT_USERNAME = "nekobot"
 _DEFAULT_PASSWORD = "nekobot"
 _JWT_SECRET_FILE = Path("data/jwt_secret.key")
 
+# Module-level persistent connection and init flag
+_conn: aiosqlite.Connection | None = None
+_initialized: bool = False
+
 
 def load_jwt_secret() -> str:
-    """Load JWT secret from env var NEKOBOT_JWT_SECRET, persisted file, or generate one."""
+    """Load JWT secret from NEKOBOT_JWT_SECRET env var, persisted file, or generate one."""
     import os
 
     env_secret = os.environ.get("NEKOBOT_JWT_SECRET", "").strip()
@@ -27,43 +31,50 @@ def load_jwt_secret() -> str:
     return secret
 
 
-async def _open(db_path: Path = _DEFAULT_DB) -> aiosqlite.Connection:
-    db_path.parent.mkdir(parents=True, exist_ok=True)
-    conn = await aiosqlite.connect(db_path)
-    conn.row_factory = aiosqlite.Row
-    return conn
+async def _get_conn(db_path: Path = _DEFAULT_DB) -> aiosqlite.Connection:
+    global _conn
+    if _conn is None:
+        db_path.parent.mkdir(parents=True, exist_ok=True)
+        _conn = await aiosqlite.connect(db_path)
+        _conn.row_factory = aiosqlite.Row
+    return _conn
 
 
 async def init_auth_db(db_path: Path = _DEFAULT_DB) -> None:
-    """Create users table and seed default admin if empty."""
-    async with await _open(db_path) as conn:
-        await conn.execute(
-            """
-            CREATE TABLE IF NOT EXISTS users (
-                username     TEXT PRIMARY KEY,
-                password_hash BLOB NOT NULL,
-                created_at   TEXT DEFAULT (datetime('now'))
-            )
-            """
+    """Create users table and seed default admin. Idempotent — safe to call at startup once."""
+    global _initialized
+    if _initialized:
+        return
+    db = await _get_conn(db_path)
+    await db.execute(
+        """
+        CREATE TABLE IF NOT EXISTS users (
+            username      TEXT PRIMARY KEY,
+            password_hash BLOB NOT NULL,
+            created_at    TEXT DEFAULT (datetime('now'))
         )
-        cursor = await conn.execute(
-            "SELECT 1 FROM users WHERE username = ?", (_DEFAULT_USERNAME,)
+        """
+    )
+    cursor = await db.execute(
+        "SELECT 1 FROM users WHERE username = ?", (_DEFAULT_USERNAME,)
+    )
+    if await cursor.fetchone() is None:
+        hashed = bcrypt.hashpw(_DEFAULT_PASSWORD.encode(), bcrypt.gensalt())
+        await db.execute(
+            "INSERT INTO users (username, password_hash) VALUES (?, ?)",
+            (_DEFAULT_USERNAME, hashed),
         )
-        if await cursor.fetchone() is None:
-            hashed = bcrypt.hashpw(_DEFAULT_PASSWORD.encode(), bcrypt.gensalt())
-            await conn.execute(
-                "INSERT INTO users (username, password_hash) VALUES (?, ?)",
-                (_DEFAULT_USERNAME, hashed),
-            )
-        await conn.commit()
+    await db.commit()
+    _initialized = True
 
 
 async def verify_password(username: str, password: str, db_path: Path = _DEFAULT_DB) -> bool:
-    async with await _open(db_path) as conn:
-        cursor = await conn.execute(
-            "SELECT password_hash FROM users WHERE username = ?", (username,)
-        )
-        row = await cursor.fetchone()
+    await init_auth_db(db_path)
+    db = await _get_conn(db_path)
+    cursor = await db.execute(
+        "SELECT password_hash FROM users WHERE username = ?", (username,)
+    )
+    row = await cursor.fetchone()
     if row is None:
         return False
     stored: bytes = bytes(row["password_hash"])
@@ -73,10 +84,11 @@ async def verify_password(username: str, password: str, db_path: Path = _DEFAULT
 async def update_password(
     username: str, new_password: str, db_path: Path = _DEFAULT_DB
 ) -> None:
+    await init_auth_db(db_path)
     hashed = bcrypt.hashpw(new_password.encode(), bcrypt.gensalt())
-    async with await _open(db_path) as conn:
-        await conn.execute(
-            "UPDATE users SET password_hash = ? WHERE username = ?",
-            (hashed, username),
-        )
-        await conn.commit()
+    db = await _get_conn(db_path)
+    await db.execute(
+        "UPDATE users SET password_hash = ? WHERE username = ?",
+        (hashed, username),
+    )
+    await db.commit()

--- a/packages/routers/routes/auth_router.py
+++ b/packages/routers/routes/auth_router.py
@@ -5,7 +5,7 @@ import datetime
 import jwt
 from quart import Blueprint, request
 
-from ..auth_store import init_auth_db, load_jwt_secret, update_password, verify_password
+from ..auth_store import load_jwt_secret, update_password, verify_password
 
 auth_bp = Blueprint("auth", __name__)
 
@@ -39,7 +39,6 @@ async def login() -> dict[str, object]:
     if not username or not password:
         return {"success": False, "message": "Missing username or password."}, 400
 
-    await init_auth_db()
     if not await verify_password(username, password):
         return {"success": False, "message": "Invalid username or password."}, 401
 
@@ -84,7 +83,6 @@ async def change_password() -> dict[str, object]:
     if not old_password or not new_password:
         return {"success": False, "message": "Missing password fields."}, 400
 
-    await init_auth_db()
     if not await verify_password(username, old_password):
         return {"success": False, "message": "Current password is incorrect."}, 403
 


### PR DESCRIPTION
## Summary
- 修复循环导入：`BootstrapConfig` 移至 `TYPE_CHECKING`，`save_app_config` 改为惰性导入
- 修复 Anthropic provider teardown 连接池泄漏
- 补全 `Any`/`Callable`/`Awaitable` 缺失导入
- auth_store 改为模块级持久连接 + 单次初始化
- CORS 默认允许 localhost:6285，支持 `*` 开发模式

## 已知遗留
- `cryptography` 未加入 pyproject.toml
- `MCPServerConfig` 缺 `args` 字段
- 2 个测试用例需更新